### PR TITLE
www/chromium: set LTO_VARS_OFF to GN_ARGS+=use_thin_lto=false

### DIFF
--- a/www/chromium/Makefile
+++ b/www/chromium/Makefile
@@ -2,6 +2,7 @@
 
 PORTNAME=	chromium
 PORTVERSION=	92.0.4515.159
+PORTREVISION=	1
 CATEGORIES=	www
 MASTER_SITES=	https://commondatastorage.googleapis.com/chromium-browser-official/ \
 		LOCAL/rene/chromium/:fonts
@@ -133,6 +134,7 @@ SUB_LIST+=	COMMENT="${COMMENT}"
 
 OPTIONS_DEFINE=	CODECS CUPS DEBUG DRIVER KERBEROS LTO TEST
 OPTIONS_DEFAULT=	CODECS CUPS DRIVER KERBEROS SNDIO
+OPTIONS_EXCLUDE_aarch64=LTO
 OPTIONS_GROUP=		AUDIO
 OPTIONS_GROUP_AUDIO=	ALSA PULSEAUDIO SNDIO
 OPTIONS_RADIO=		KERBEROS
@@ -181,6 +183,7 @@ KERBEROS_VARS_OFF=	GN_ARGS+=use_kerberos=false
 LTO_VARS=		GN_ARGS+=use_thin_lto=true \
 			GN_ARGS+=thin_lto_enable_optimizations=true \
 			WANTSPACE="14 GB"
+LTO_VARS_OFF=		GN_ARGS+=use_thin_lto=false
 
 MIT_LIB_DEPENDS=	libkrb.so.3:security/krb5
 PULSEAUDIO_LIB_DEPENDS=	libpulse.so:audio/pulseaudio


### PR DESCRIPTION
Set LTO_VARS_OFF to GN_ARGS+=use_thin_lto=false otherwise LTO is enabled unconditionnaly.
Disable LTO on aarch64 as it causes link failure
Bump PORTREVISION as chromium is really built with lto off now.

PR:	257468